### PR TITLE
Add the ability to specify a regex on an event property

### DIFF
--- a/tests/test_yaml_event_property.py
+++ b/tests/test_yaml_event_property.py
@@ -11,6 +11,7 @@ def property_yaml_obj():
     type: string
     required: false
     allowNull: true
+    pattern: "experiment|control"
 """)
 
 def test_parsing_top_level_attrs(property_yaml_obj):
@@ -36,6 +37,7 @@ def test_to_json(property_yaml_obj):
 
     expected = {
         'description': 'What variation of the group',
+        'pattern': 'experiment|control',
         'type': [
             'string',
             'null'

--- a/tests/test_yaml_event_property.py
+++ b/tests/test_yaml_event_property.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 from tracking_plan.yaml_event_property import YamlEventProperty
-
+from tracking_plan.errors import ValidationError
 
 @pytest.fixture
 def property_yaml_obj():
@@ -48,3 +48,11 @@ def test_to_json(property_yaml_obj):
     actual = prop.to_json()
 
     assert expected == actual
+
+def test_validate_pattern_on_string_type(property_yaml_obj):
+    property_yaml_obj['type'] = 'number'
+    with pytest.raises(ValidationError) as err_info:
+        YamlEventProperty(property_yaml_obj)
+    expected_msg = f'Property variation cannot specify a pattern'
+
+    assert expected_msg in str(err_info.value)

--- a/tracking_plan/errors.py
+++ b/tracking_plan/errors.py
@@ -1,0 +1,2 @@
+class ValidationError(Exception):
+    pass

--- a/tracking_plan/yaml_event_property.py
+++ b/tracking_plan/yaml_event_property.py
@@ -22,6 +22,10 @@ class YamlEventProperty(object):
     def allow_null(self):
         return self._property_yaml.get('allowNull', False)
 
+    @property
+    def pattern(self):
+        return self._property_yaml.get('pattern')
+
     @classmethod
     def from_yaml(cls, property_yaml):
         return cls(property_yaml)
@@ -31,8 +35,12 @@ class YamlEventProperty(object):
         if self.allow_null:
             p_types.append('null')
 
-        return {
+        output = {
             'description': self.description,
             'type': p_types,
             'id': f"/properties/properties/properties/{self.name}"
         }
+        if self.pattern:
+            output['pattern'] = self.pattern
+
+        return output

--- a/tracking_plan/yaml_event_property.py
+++ b/tracking_plan/yaml_event_property.py
@@ -1,6 +1,9 @@
+from tracking_plan.errors import ValidationError
+
 class YamlEventProperty(object):
     def __init__(self, property_yaml):
         self._property_yaml = property_yaml
+        self.validate()
 
     @property
     def name(self):
@@ -44,3 +47,11 @@ class YamlEventProperty(object):
             output['pattern'] = self.pattern
 
         return output
+
+    def _check_if_pattern_is_valid(self):
+        if self.type != 'string' and self.pattern:
+            message = f'Property {self.name} cannot specify a pattern. It''s of type {self.type}.'
+            raise ValidationError(message)
+
+    def validate(self):
+        self._check_if_pattern_is_valid()


### PR DESCRIPTION
Let's us add regexes to event properties (using the `pattern` nomenclature that Segment uses) 