### PR TITLE
Omit "any" type from json output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(
-    version="0.0.5",
+    version="0.0.6",
     name="tracking-plan-kit",
     packages=["tracking_plan", "cli", "segment"],
     include_package_data=True,

--- a/tests/test_yaml_property.py
+++ b/tests/test_yaml_property.py
@@ -16,6 +16,14 @@ def property_yaml_obj():
     pattern: "experiment|control"
 """)
 
+@pytest.fixture
+def property_type_any_yaml_obj():
+    return  yaml.safe_load("""
+    name: version
+    description: This could be a string or integer
+    type: any
+""")
+
 def test_parsing_top_level_attrs(property_yaml_obj):
     prop = YamlProperty.from_yaml(property_yaml_obj)
 
@@ -72,3 +80,10 @@ def test_valid_name(property_yaml_obj):
 
     with assert_raises_validation_error(expected_msg="FooBar is not a valid property name"):
         YamlProperty(property_yaml_obj)
+
+def test_type_any_to_json(property_type_any_yaml_obj):
+    prop = YamlProperty.from_yaml(property_type_any_yaml_obj)
+
+    actual = prop.to_json()
+
+    assert 'type' not in actual

--- a/tracking_plan/yaml_property.py
+++ b/tracking_plan/yaml_property.py
@@ -36,14 +36,13 @@ class YamlProperty(object):
         return cls(property_yaml)
 
     def to_json(self):
-        p_types = [self.type]
-        if self.allow_null:
-            p_types.append('null')
-
         output = {
             'description': self.description,
-            'type': p_types
         }
+        if self.type != 'any':
+            output['type'] = [self.type]
+            if self.allow_null:
+                output['type'].append('null')
         if self.pattern:
             output['pattern'] = self.pattern
 


### PR DESCRIPTION
### Purpose
Segment's Protocol's UI sets no type value for the "any" data type as it's not a type found in the JSON schema that this feature is based off of.

### Notes
This was discovered when trying to work with [Typewriter](https://segment.com/docs/protocols/typewriter/) tool which flagged "any" as an invalid type.