### PR TITLE
Add validation for duplicate properties on events

### DIFF
--- a/tests/test_yaml_event.py
+++ b/tests/test_yaml_event.py
@@ -31,6 +31,22 @@ def tag_created_yaml_obj():
     properties: []
   """)
 
+@pytest.fixture
+def dup_properties_yaml_obj():
+  return yaml.safe_load("""
+  name: Foo Created
+  description: foo
+  area: product
+  properties:
+    - name: foo
+      description: foo
+      type: string
+      required: true
+    - name: foo
+      description: foo
+      type: string
+  """)
+
 def test_parsing_top_level_attrs(experiments_yaml_obj):
     event = YamlEvent.from_yaml(experiments_yaml_obj)
 
@@ -90,6 +106,10 @@ def test_required_fields(tag_created_yaml_obj):
   assert_required(YamlEvent, tag_created_yaml_obj, 'name')
   assert_required(YamlEvent, tag_created_yaml_obj, 'description')
   assert_required(YamlEvent, tag_created_yaml_obj, 'area')
+
+def test_duplicate_properties(dup_properties_yaml_obj):
+  with assert_raises_validation_error(f'Duplicate properties found on event Foo Created. Properties: foo'):
+      YamlEvent.from_yaml(dup_properties_yaml_obj)
 
 def test_valid_name(tag_created_yaml_obj):
   tag_created_yaml_obj['name'] = 'Foo bar'

--- a/tracking_plan/yaml_event.py
+++ b/tracking_plan/yaml_event.py
@@ -2,6 +2,7 @@ from tracking_plan.yaml_property import YamlProperty
 from tracking_plan.errors import ValidationError
 from tracking_plan.string_utilities import is_sentence_case
 from tracking_plan.validation import check_required
+from collections import Counter
 
 class YamlEvent(object):
     def __init__(self, event_yaml):
@@ -58,6 +59,18 @@ class YamlEvent(object):
         if not is_sentence_case(self.name):
             raise ValidationError(f'{self.name} is not a valid event name')
 
+    def _check_duplicate_properties(self):
+        if len(self.properties) == 0:
+            return
+        prop_names = [p.name for p in self.properties]
+        counts = Counter(prop_names)
+
+        duplicates = {k:v for (k,v) in counts.items() if v > 1}
+        if len(duplicates) > 0:
+            duplicate_names = ', '.join(duplicates.keys())
+            raise ValidationError(f'Duplicate properties found on event {self.name}. Properties: {duplicate_names}')
+
     def validate(self):
         check_required(self, 'area', 'description', 'name', 'properties')
+        self._check_duplicate_properties()
         self._check_valid_name()


### PR DESCRIPTION
### Purpose
Through some [investigation](https://buffer.slack.com/archives/CHRPK6R6D/p1594736235004900), I discovered that we introduced duplicate property names on a number of events in this PR: 

https://github.com/bufferapp/tracking-plan/pull/184

This has caused the automated deployment of our tracking plan to Segment to fail for more than a week.

Honestly I'm surprised this hasn't come up before, but in this PR I've added a validation to check that events do not have duplicate properties. 