### PR TITLE
Support Group Traits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(
-    version="0.0.6",
+    version="0.1.0",
     name="tracking-plan-kit",
     packages=["tracking_plan", "cli", "segment"],
     include_package_data=True,

--- a/tests/test_tracking_plan_loader.py
+++ b/tests/test_tracking_plan_loader.py
@@ -40,6 +40,14 @@ traits:
     allowNull: true
 """
 
+GROUP_FILE = """
+traits:
+  - name: organizationID
+    description: organizationID
+    type: string
+    required: false
+    allowNull: false
+"""
 def _create_plan_file(tmpdir):
   p = tmpdir / "plan.yaml"
   p.write(TRACKING_PLAN_FILE)
@@ -51,6 +59,10 @@ def _create_events(tmpdir, contents=EVENT_FILE):
 def _create_identify_file(tmpdir):
   i = tmpdir / "identify_traits.yaml"
   i.write(IDENTIFY_FILE)
+
+def _create_group_file(tmpdir):
+  g = tmpdir / "group_traits.yaml"
+  g.write(GROUP_FILE)
 
 def test_loader_tracking_plan(tmpdir):
     _create_plan_file(tmpdir)
@@ -84,6 +96,15 @@ def test_loader_identify(tmpdir):
   traits = loader.plan.identify_traits
 
   assert len(traits) == 2
+
+def test_loader_group(tmpdir):
+  _create_plan_file(tmpdir)
+  _create_group_file(tmpdir)
+
+  loader = PlanLoader(tmpdir)
+  traits = loader.plan.group_traits
+
+  assert len(traits) == 1
 
 def test_loader_validation(tmpdir):
   _create_plan_file(tmpdir)

--- a/tests/test_yaml_tracking_plan.py
+++ b/tests/test_yaml_tracking_plan.py
@@ -49,6 +49,12 @@ def test_adding_identify_traits(tracking_plan_yaml, tracking_plan_trait_yaml):
 
     assert len(plan.identify_traits) == 1
 
+def test_adding_group_traits(tracking_plan_yaml, tracking_plan_trait_yaml):
+    plan = YamlTrackingPlan.from_yaml(tracking_plan_yaml)
+
+    plan.add_group_trait(tracking_plan_trait_yaml)
+
+    assert len(plan.group_traits) == 1
 
 def test_to_json_top_level_attrs(tracking_plan_yaml, tracking_plan_event_yaml):
     plan = YamlTrackingPlan(tracking_plan_yaml)

--- a/tests/test_yaml_tracking_plan.py
+++ b/tests/test_yaml_tracking_plan.py
@@ -89,6 +89,19 @@ def test_to_json_traits(tracking_plan_yaml, tracking_plan_trait_yaml):
     actual = json_traits['email']
     assert actual == expected
 
+def test_to_json_group_traits(tracking_plan_yaml, tracking_plan_trait_yaml):
+    plan = YamlTrackingPlan(tracking_plan_yaml)
+    plan.add_group_trait(tracking_plan_trait_yaml)
+
+    json_plan = plan.to_json()
+
+    json_traits = json_plan['rules']['group']['properties']['traits']['properties']
+
+    assert len(json_traits) == 1
+    expected = YamlProperty(tracking_plan_trait_yaml).to_json()
+    actual = json_traits['email']
+    assert actual == expected
+
 def test_required_fields(tracking_plan_yaml):
     assert_required(YamlTrackingPlan, tracking_plan_yaml, 'name')
 

--- a/tracking_plan/json_tracking_plan.py
+++ b/tracking_plan/json_tracking_plan.py
@@ -58,6 +58,17 @@ class JsonTrackingPlan(object):
         if traits_json:
             self._dump_identify_file(root_dir, traits_json)
 
+        group_traits_json = self._json_obj. \
+            get('rules'). \
+            get('group', {}). \
+            get('properties', {}). \
+            get('traits', {}). \
+            get('properties')
+
+        if group_traits_json:
+            self._dump_group_file(root_dir, group_traits_json)
+
+
         # dump the events
         for event_json in self._json_obj.get('rules', {}).get('events', []):
             self._dump_event_file(events_dir, event_json)
@@ -104,6 +115,18 @@ class JsonTrackingPlan(object):
             'traits': traits
         }
         traits_file = os.path.join(root_dir, 'identify_traits.yaml')
+
+        with open(traits_file, 'w') as f:
+            yaml.dump(traits_obj, f, sort_keys=False)
+
+    def _dump_group_file(self, root_dir, group_traits_json):
+        traits = [parse_json_property(name, prop_json)
+            for (name, prop_json) in group_traits_json.items()]
+
+        traits_obj = {
+            'traits': traits
+        }
+        traits_file = os.path.join(root_dir, 'group_traits.yaml')
 
         with open(traits_file, 'w') as f:
             yaml.dump(traits_obj, f, sort_keys=False)

--- a/tracking_plan/plan_loader.py
+++ b/tracking_plan/plan_loader.py
@@ -9,7 +9,8 @@ class PlanLoader(object):
         try:
             self._load_plan_file(root_dir / "plan.yaml")
             self._load_events(root_dir / "events")
-            self._load_identify_traits(root_dir/ "identify_traits.yaml")
+            self._load_identify_traits(root_dir / "identify_traits.yaml")
+            self._load_group_traits(root_dir / "group_traits.yaml")
         except ValidationError as error:
             if raise_validation_errors:
                 raise error
@@ -34,6 +35,15 @@ class PlanLoader(object):
             yaml_obj = yaml.safe_load(idf)
             for trait in yaml_obj.get('traits', []):
                 self._plan.add_identify_trait(trait)
+
+    def _load_group_traits(self, path):
+        if not path.exists():
+            return
+        with open(path, 'r') as grp:
+            yaml_obj = yaml.safe_load(grp)
+            for trait in yaml_obj.get('traits', []):
+                self._plan.add_group_trait(trait)
+
 
 
     @property

--- a/tracking_plan/yaml_tracking_plan.py
+++ b/tracking_plan/yaml_tracking_plan.py
@@ -77,6 +77,18 @@ class YamlTrackingPlan(object):
                 "type": "object"
             }
 
+        if len(self.group_traits) > 0:
+            trait_properties = {t.name: t.to_json() for t in self.group_traits}
+            json_obj['rules']['group'] = {
+                'properties' : {
+                    'traits' : {
+                        'properties' : trait_properties
+                    }
+                },
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object"
+            }
+
         return json_obj
 
     def _check_duplicate_events(self):

--- a/tracking_plan/yaml_tracking_plan.py
+++ b/tracking_plan/yaml_tracking_plan.py
@@ -9,6 +9,7 @@ class YamlTrackingPlan(object):
         self._plan_yaml = plan_yaml
         self._events = []
         self._identify_traits = []
+        self._group_traits = []
         self.validate()
 
     @classmethod
@@ -32,6 +33,11 @@ class YamlTrackingPlan(object):
     def identify_traits(self):
         return self._identify_traits
 
+    @property
+    def group_traits(self):
+        return self._group_traits
+
+
     def add_event(self, event_yaml):
         event = YamlEvent(event_yaml)
         self._events.append(event)
@@ -40,6 +46,10 @@ class YamlTrackingPlan(object):
     def add_identify_trait(self, trait_yaml):
         trait_property = YamlProperty(trait_yaml)
         self._identify_traits.append(trait_property)
+
+    def add_group_trait(self, trait_yaml):
+        trait_property = YamlProperty(trait_yaml)
+        self._group_traits.append(trait_property)
 
     def to_json(self):
         json_obj = {


### PR DESCRIPTION
Add support for specifying Group Traits in our yaml tracking plan. Traits will live in the `group_traits.yaml` file, for example:

```yaml
traits:
- name: organizationId
  description: 'The Global Organization ID associated with this group.'
  type: string
```